### PR TITLE
fix auth for release build

### DIFF
--- a/kotlinblog-backend/kt-authentication/pom.xml
+++ b/kotlinblog-backend/kt-authentication/pom.xml
@@ -23,10 +23,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
fix the `main class not found` error for kt-auth